### PR TITLE
Fix build, update to wlroots v0.7.0

### DIFF
--- a/wlroots/wlroots.go
+++ b/wlroots/wlroots.go
@@ -751,7 +751,7 @@ func (o Output) DestroyGlobal() {
 }
 
 func (o Output) Commit() {
-	C.wlr_output_commit(o.p, nil, nil)
+	C.wlr_output_commit(o.p)
 }
 
 func (o Output) Modes() []OutputMode {
@@ -808,10 +808,6 @@ func (l OutputLayout) Coords(output Output) (x float64, y float64) {
 
 func OutputTransformInvert(transform uint32) uint32 {
 	return uint32(C.wlr_output_transform_invert(C.enum_wl_output_transform(transform)))
-}
-
-func (m OutputMode) Flags() uint32 {
-	return uint32(m.p.flags)
 }
 
 func (m OutputMode) Width() int32 {


### PR DESCRIPTION
	# github.com/swaywm/go-wlroots/wlroots
	wlroots/wlroots.go:754:21: too many arguments in call to _Cfunc_wlr_output_commit
		have (*_Ctype_struct_wlr_output, nil, nil)
		want (*_Ctype_struct_wlr_output)
	wlroots/wlroots.go:814:19: m.p.flags undefined (type *_Ctype_struct_wlr_output_mode has no field or method flags)
	make: *** [Makefile:6: tinywl] Error 2

Fixes #9.