### PR TITLE
flake: add tinywl package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -5,16 +5,37 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701687253,
+        "narHash": "sha256-qJCMxIKWXonJODPF2oV7mCd0xu7VYVenTucrY0bizto=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "001bbfa22e2adeb87c34c6015e5694e88721cabe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
         "type": "github"
       }
     },
@@ -35,8 +56,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
       }
     },
     "systems": {
@@ -51,6 +73,39 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,63 @@
 {
   description = "Nix flake for go-wlroots";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+    gomod2nix = {
+      url = "github:tweag/gomod2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-  outputs = { self, flake-utils, nixpkgs }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs = { self, nixpkgs, utils, gomod2nix }:
+    utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
+          overlays = [ gomod2nix.overlays.default ];
         };
-      in {
-        devShell = with pkgs; mkShell {
+        libxkbcommon =
+          pkgs.libxkbcommon.overrideAttrs (finalAttrs: prevAttrs: rec {
+            version = "1.6.0";
+            src = pkgs.fetchurl {
+              url = "https://xkbcommon.org/download/${prevAttrs.pname}-${version}.tar.xz";
+              hash = "sha256-DtwU7M3TkVFEWLxfWkuZhj7S1lHk3XYakKv09G75nCs=";
+            };
+          });
+      in
+      {
+        packages = rec {
+          default = tinywl;
+          tinywl = with pkgs; buildGoApplication {
+            pname = "tinywl";
+            version = "v0.0.0";
+            src = ./.;
+            subPackages = "cmd/tinywl";
+            modules = ./gomod2nix.toml;
+            nativeBuildInputs = [ pkg-config wayland ];
+            buildInputs = [
+              libxkbcommon
+              pixman
+              wlroots
+              wayland
+              libGL
+              udev
+              xorg.libX11
+              xorg.xcbutilwm
+            ];
+            preBuild = ''
+              wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.c
+              wayland-scanner server-header ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.h
+            '';
+          };
+        };
+        devShells.default = with pkgs; mkShell {
           buildInputs = [
             gcc
             go
-            (libxkbcommon.overrideAttrs(finalAttrs: prevAttrs: rec {
-              version = "1.6.0";
-              src = fetchurl {
-                url = "https://xkbcommon.org/download/${prevAttrs.pname}-${version}.tar.xz";
-                hash = "sha256-DtwU7M3TkVFEWLxfWkuZhj7S1lHk3XYakKv09G75nCs=";
-              };
-            }))
+            gopls
+            gomod2nix.packages.${system}.default
+            libxkbcommon
             wlroots
             pkg-config
             wayland

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,6 @@
+schema = 3
+
+[mod]
+  [mod."golang.org/x/sys"]
+    version = "v0.15.0"
+    hash = "sha256-n7TlABF6179RzGq3gctPDKDPRtDfnwPdjNCMm8ps2KY="


### PR DESCRIPTION
adds a tinywl package to the Nix flake, which replicates the Makefile's functionality with Nix. Uses gomod2nix to manage the one Go module.

Also adds the gopls LSP to the devShell for editor integration.