### PR TITLE
TinyWL Server: Nil check xdgSurface in topLevelAt

### DIFF
--- a/cmd/tinywl/server.go
+++ b/cmd/tinywl/server.go
@@ -217,7 +217,11 @@ func (s *Server) topLevelAt(lx float64, ly float64) (*wlroots.XDGTopLevel, *wlro
 	/* Find the node corresponding to the tinywl_toplevel at the root of this
 	 * surface tree, it is the only one for which we set the data field. */
 
-	topLevel := surface.XDGSurface().TopLevel()
+	xdgSurface := surface.XDGSurface()
+	if xdgSurface.Nil() {
+		return nil, nil, 0, 0
+	}
+	topLevel := xdgSurface.TopLevel()
 	slog.Debug("topLevelAt", "topLevel", topLevel)
 	slog.Debug("topLevelAt", "s.topLevelList.Len()", s.topLevelList.Len())
 


### PR DESCRIPTION
This can be Nil, To reproduce, run tinywl -s foot, then:

- Mouse over foot
- Mouse to the title bar decorations
- crash