### PR TITLE
Update for wlroots 0.18

### DIFF
--- a/cmd/tinywl/server.go
+++ b/cmd/tinywl/server.go
@@ -254,7 +254,7 @@ func (s *Server) handleOutputRequestState(output wlroots.Output, state wlroots.O
 	output.CommitState(state)
 }
 
-func (s *Server) handleOuptuDestroy(output wlroots.Output) {
+func (s *Server) handleOutputDestroy(output wlroots.Output) {
 	slog.Debug("handleDestroy", "output", output)
 }
 
@@ -292,7 +292,7 @@ func (s *Server) handleNewOutput(output wlroots.Output) {
 	output.OnRequestState(s.handleOutputRequestState)
 
 	/* Sets up a listener for the destroy event. */
-	output.OnDestroy(s.handleOuptuDestroy)
+	output.OnDestroy(s.handleOutputDestroy)
 
 	/* Adds this to the output layout. The add_auto function arranges outputs
 	 * from left-to-right in the order they appear. A more sophisticated

--- a/cmd/tinywl/server.go
+++ b/cmd/tinywl/server.go
@@ -477,7 +477,7 @@ func (s *Server) handleCursorAxis(_ wlroots.InputDevice, time uint32, source wlr
 	 * for example when you move the scroll wheel. */
 
 	/* Notify the client with pointer focus of the axis event. */
-	s.seat.NotifyPointerAxis(time, orientation, delta, deltaDiscrete, source)
+	s.seat.NotifyPointerAxis(time, orientation, delta, deltaDiscrete, source, wlroots.RelativeDirectionIdentical)
 }
 
 func (s *Server) handleCursorFrame() {
@@ -660,7 +660,7 @@ func NewServer() (s *Server, err error) {
 
 	/* Creates an output layout, which a wlroots utility for working with an
 	 * arrangement of screens in a physical layout. */
-	s.outputLayout = wlroots.NewOutputLayout()
+	s.outputLayout = wlroots.NewOutputLayout(s.display)
 
 	/* Configure a listener to be notified when new outputs are available on the
 	 * backend. */

--- a/cmd/tinywl/server.go
+++ b/cmd/tinywl/server.go
@@ -276,7 +276,7 @@ func (s *Server) handleNewOutput(output wlroots.Output) {
 	 * refresh rate), and each monitor supports only a specific set of modes. We
 	 * just pick the monitor's preferred mode, a more sophisticated compositor
 	 * would let the user configure it. */
-	mode, err := output.PrefferedMode()
+	mode, err := output.PreferredMode()
 	if err == nil {
 		oState.SetMode(mode)
 	}

--- a/flake.lock
+++ b/flake.lock
@@ -5,47 +5,26 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gomod2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1701687253,
-        "narHash": "sha256-qJCMxIKWXonJODPF2oV7mCd0xu7VYVenTucrY0bizto=",
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "rev": "001bbfa22e2adeb87c34c6015e5694e88721cabe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "gomod2nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {
@@ -56,9 +35,8 @@
     },
     "root": {
       "inputs": {
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -73,39 +51,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,70 +2,65 @@
   description = "Nix flake for go-wlroots";
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
-    utils.url = "github:numtide/flake-utils";
-    gomod2nix = {
-      url = "github:tweag/gomod2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, utils, gomod2nix }:
-    utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ gomod2nix.overlays.default ];
+        pkgs = nixpkgs.legacyPackages.${system};
+        tinywl = pkgs.buildGoModule {
+          pname = "tinywl";
+          version = "0.0.0";
+          src = self;
+          vendorHash = "sha256-0vsi8q/+H7I5qvyr9sIZFLD30yZivySLWYT6KrJqIcc=";
+          subPackages = [ "cmd/tinywl" ];
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.wayland-scanner
+          ];
+          buildInputs = [
+            pkgs.libxkbcommon
+            pkgs.pixman
+            pkgs.wlroots
+            pkgs.wayland
+            pkgs.libGL
+            pkgs.udev
+            pkgs.xorg.libX11
+            pkgs.xorg.xcbutilwm
+          ];
+          preBuild = ''
+            wayland-scanner private-code ${pkgs.wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.c
+            wayland-scanner server-header ${pkgs.wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.h
+          '';
         };
-        libxkbcommon =
-          pkgs.libxkbcommon.overrideAttrs (finalAttrs: prevAttrs: rec {
-            version = "1.6.0";
-            src = pkgs.fetchurl {
-              url = "https://xkbcommon.org/download/${prevAttrs.pname}-${version}.tar.xz";
-              hash = "sha256-DtwU7M3TkVFEWLxfWkuZhj7S1lHk3XYakKv09G75nCs=";
-            };
-          });
       in
       {
-        packages = rec {
+        packages = {
+          inherit tinywl;
           default = tinywl;
-          tinywl = with pkgs; buildGoApplication {
-            pname = "tinywl";
-            version = "v0.0.0";
-            src = ./.;
-            subPackages = "cmd/tinywl";
-            modules = ./gomod2nix.toml;
-            nativeBuildInputs = [ pkg-config wayland ];
-            buildInputs = [
-              libxkbcommon
-              pixman
-              wlroots
-              wayland
-              libGL
-              udev
-              xorg.libX11
-              xorg.xcbutilwm
-            ];
-            preBuild = ''
-              wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.c
-              wayland-scanner server-header ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.h
-            '';
-          };
         };
-        devShells.default = with pkgs; mkShell {
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ tinywl ];
           buildInputs = [
-            gcc
-            go
-            gopls
-            gomod2nix.packages.${system}.default
-            libxkbcommon
-            wlroots
-            pkg-config
-            wayland
-            udev
-            libGL
-            pixman
-            xorg.libX11
-            xorg.xcbutilwm
+            pkgs.gcc
+            pkgs.go
+            pkgs.gopls
+            pkgs.libxkbcommon
+            pkgs.wlroots
+            pkgs.pkg-config
+            pkgs.wayland
+            pkgs.udev
+            pkgs.libGL
+            pkgs.pixman
+            pkgs.xorg.libX11
+            pkgs.xorg.xcbutilwm
           ];
         };
       }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/swaywm/go-wlroots
 
-go 1.21
+go 1.23.0
 
-require golang.org/x/sys v0.15.0
+toolchain go1.24.2
+
+require golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,6 +1,0 @@
-schema = 3
-
-[mod]
-  [mod."golang.org/x/sys"]
-    version = "v0.15.0"
-    hash = "sha256-n7TlABF6179RzGq3gctPDKDPRtDfnwPdjNCMm8ps2KY="

--- a/wlroots/backend.go
+++ b/wlroots/backend.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/backend.h>
 // #include <wlr/render/allocator.h>

--- a/wlroots/buffer.go
+++ b/wlroots/buffer.go
@@ -5,7 +5,7 @@ package wlroots
  * future consistency of this API.
  */
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_buffer.h>
 import "C"

--- a/wlroots/compositor.go
+++ b/wlroots/compositor.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <time.h>

--- a/wlroots/cursor.go
+++ b/wlroots/cursor.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <wlr/types/wlr_cursor.h>
@@ -79,7 +79,8 @@ func (c Cursor) MapInputToOutput(input InputDevice, output Output) {
  * struct wlr_output_layout.
  */
 func (c Cursor) MapToRegion(box GeoBox) {
-	C.wlr_cursor_map_to_region(c.p, box.p)
+	cbox := box.toC()
+	C.wlr_cursor_map_to_region(c.p, &cbox)
 }
 
 /**
@@ -87,7 +88,8 @@ func (c Cursor) MapToRegion(box GeoBox) {
  * struct wlr_output_layout.
  */
 func (c Cursor) MapInputToRegion(dev InputDevice, box GeoBox) {
-	C.wlr_cursor_map_input_to_region(c.p, dev.p, box.p)
+	cbox := box.toC()
+	C.wlr_cursor_map_input_to_region(c.p, dev.p, &cbox)
 }
 
 /**

--- a/wlroots/input_device.go
+++ b/wlroots/input_device.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_input_device.h>
 // #include <wlr/types/wlr_keyboard.h>
@@ -18,10 +18,11 @@ import (
 import "C"
 
 type (
-	InputDeviceType uint32
-	ButtonState     uint32
-	AxisSource      uint32
-	AxisOrientation uint32
+	InputDeviceType   uint32
+	ButtonState       uint32
+	AxisSource        uint32
+	AxisOrientation   uint32
+	RelativeDirection uint32
 )
 
 var inputDeviceNames = []string{
@@ -36,20 +37,23 @@ const (
 	InputDeviceTypeKeyboard   InputDeviceType = C.WLR_INPUT_DEVICE_KEYBOARD
 	InputDeviceTypePointer    InputDeviceType = C.WLR_INPUT_DEVICE_POINTER
 	InputDeviceTypeTouch      InputDeviceType = C.WLR_INPUT_DEVICE_TOUCH
-	InputDeviceTypeTabletTool InputDeviceType = C.WLR_INPUT_DEVICE_TABLET_TOOL
+	InputDeviceTypeTabletTool InputDeviceType = C.WLR_INPUT_DEVICE_TABLET
 	InputDeviceTypeTabletPad  InputDeviceType = C.WLR_INPUT_DEVICE_TABLET_PAD
 	InputDeviceTypeSwitch     InputDeviceType = C.WLR_INPUT_DEVICE_SWITCH
 
 	ButtonStateReleased ButtonState = C.WLR_BUTTON_RELEASED
 	ButtonStatePressed  ButtonState = C.WLR_BUTTON_PRESSED
 
-	AxisSourceWheel      AxisSource = C.WLR_AXIS_SOURCE_WHEEL
-	AxisSourceFinger     AxisSource = C.WLR_AXIS_SOURCE_FINGER
-	AxisSourceContinuous AxisSource = C.WLR_AXIS_SOURCE_CONTINUOUS
-	AxisSourceWheelTilt  AxisSource = C.WLR_AXIS_SOURCE_WHEEL_TILT
+	AxisSourceWheel      AxisSource = C.WL_POINTER_AXIS_SOURCE_WHEEL
+	AxisSourceFinger     AxisSource = C.WL_POINTER_AXIS_SOURCE_FINGER
+	AxisSourceContinuous AxisSource = C.WL_POINTER_AXIS_SOURCE_CONTINUOUS
+	AxisSourceWheelTilt  AxisSource = C.WL_POINTER_AXIS_SOURCE_WHEEL_TILT
 
-	AxisOrientationVertical   AxisOrientation = C.WLR_AXIS_ORIENTATION_VERTICAL
-	AxisOrientationHorizontal AxisOrientation = C.WLR_AXIS_ORIENTATION_HORIZONTAL
+	AxisOrientationVertical   AxisOrientation = C.WL_POINTER_AXIS_VERTICAL_SCROLL
+	AxisOrientationHorizontal AxisOrientation = C.WL_POINTER_AXIS_HORIZONTAL_SCROLL
+
+	RelativeDirectionIdentical RelativeDirection = C.WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL
+	RelativeDirectionInverted  RelativeDirection = C.WL_POINTER_AXIS_RELATIVE_DIRECTION_INVERTED
 )
 
 type InputDevice struct {
@@ -63,8 +67,6 @@ func (d InputDevice) OnDestroy(cb func(InputDevice)) {
 }
 
 func (d InputDevice) Type() InputDeviceType { return InputDeviceType(d.p._type) }
-func (d InputDevice) Vendor() int           { return int(d.p.vendor) }
-func (d InputDevice) Product() int          { return int(d.p.product) }
 func (d InputDevice) Name() string          { return C.GoString(d.p.name) }
 
 func validateInputDeviceType(d InputDevice, fn string, req InputDeviceType) {

--- a/wlroots/keyboard.go
+++ b/wlroots/keyboard.go
@@ -11,7 +11,7 @@ import (
 	"github.com/swaywm/go-wlroots/xkb"
 )
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_input_device.h>
 // #include <wlr/types/wlr_keyboard.h>

--- a/wlroots/listener_manager.go
+++ b/wlroots/listener_manager.go
@@ -23,7 +23,7 @@ import (
 //
 // Send help.
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <wayland-server-core.h>

--- a/wlroots/log.go
+++ b/wlroots/log.go
@@ -5,9 +5,7 @@ package wlroots
  * future consistency of this API.
  */
 
-// #cgo pkg-config: wlroots wayland-server
-// #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <stdio.h>

--- a/wlroots/output.go
+++ b/wlroots/output.go
@@ -208,7 +208,7 @@ func (o Output) SetMode(mode OutputMode) {
  * Returns the preferred mode for this output. If the output doesn't support
  * modes, returns NULL.
  */
-func (o Output) PrefferedMode() (OutputMode, error) {
+func (o Output) PreferredMode() (OutputMode, error) {
 	mode := C.wlr_output_preferred_mode(o.p)
 	if mode == nil {
 		return OutputMode{}, errors.New("no preferred mode")

--- a/wlroots/render_pass.go
+++ b/wlroots/render_pass.go
@@ -1,0 +1,54 @@
+package wlroots
+
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+
+// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
+// #include <wlr/render/wlr_renderer.h>
+import "C"
+
+type (
+	BlendMode  uint32
+	FilterMode uint32
+)
+
+const (
+	BlendModePremultiplied BlendMode = C.WLR_RENDER_BLEND_MODE_PREMULTIPLIED
+	BlendModeNone          BlendMode = C.WLR_RENDER_BLEND_MODE_NONE
+
+	FilterBilinear FilterMode = C.WLR_SCALE_FILTER_BILINEAR
+	FilterNearest  FilterMode = C.WLR_SCALE_FILTER_NEAREST
+)
+
+type RenderPass struct {
+	p *C.struct_wlr_render_pass
+}
+
+func (r RenderPass) Submit() {
+	C.wlr_render_pass_submit(r.p)
+}
+
+func (r RenderPass) AddTexture(texture Texture, srcBox FBox, dstBox GeoBox, alpha float32, transform uint32, filterMode FilterMode, blendMode BlendMode) {
+	var alphaC C.float
+	alphaC = C.float(alpha)
+	var options C.struct_wlr_render_texture_options
+	options.texture = texture.p
+	options.src_box = srcBox.toC()
+	options.dst_box = dstBox.toC()
+	options.alpha = &alphaC
+	options.transform = C.enum_wl_output_transform(transform)
+	options.filter_mode = uint32(filterMode)
+	options.blend_mode = uint32(blendMode)
+	C.wlr_render_pass_add_texture(r.p, &options)
+}
+
+func (r RenderPass) AddRect(box *GeoBox, color *Color, blendMode BlendMode) {
+	var options C.struct_wlr_render_rect_options
+	options.box = box.toC()
+	options.color = color.toC()
+	options.blend_mode = uint32(blendMode)
+	C.wlr_render_pass_add_rect(r.p, &options)
+}

--- a/wlroots/renderer.go
+++ b/wlroots/renderer.go
@@ -29,28 +29,3 @@ func (r Renderer) OnDestroy(cb func(Renderer)) {
 func (r Renderer) InitDisplay(display Display) {
 	C.wlr_renderer_init_wl_display(r.p, display.p)
 }
-
-func (r Renderer) Begin(output Output, width int, height int) {
-	C.wlr_renderer_begin(r.p, C.uint(width), C.uint(height))
-}
-
-func (r Renderer) Clear(color *Color) {
-	c := color.toC()
-	C.wlr_renderer_clear(r.p, &c[0])
-}
-
-func (r Renderer) End() {
-	C.wlr_renderer_end(r.p)
-}
-
-func (r Renderer) RenderTextureWithMatrix(texture Texture, matrix *Matrix, alpha float32) {
-	m := matrix.toC()
-	C.wlr_render_texture_with_matrix(r.p, texture.p, &m[0], C.float(alpha))
-}
-
-func (r Renderer) RenderRect(box *GeoBox, color *Color, projection *Matrix) {
-	b := box.toC()
-	c := color.toC()
-	pm := projection.toC()
-	C.wlr_render_rect(r.p, &b, &c[0], &pm[0])
-}

--- a/wlroots/renderer.go
+++ b/wlroots/renderer.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/render/wlr_renderer.h>
 import "C"

--- a/wlroots/scene.go
+++ b/wlroots/scene.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_scene.h>
 import "C"

--- a/wlroots/seat.go
+++ b/wlroots/seat.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_seat.h>
 import "C"
@@ -67,8 +67,8 @@ func (s Seat) NotifyPointerButton(time uint32, button uint32, state ButtonState)
 	C.wlr_seat_pointer_notify_button(s.p, C.uint32_t(time), C.uint32_t(button), uint32(state))
 }
 
-func (s Seat) NotifyPointerAxis(time uint32, orientation AxisOrientation, delta float64, deltaDiscrete int32, source AxisSource) {
-	C.wlr_seat_pointer_notify_axis(s.p, C.uint32_t(time), C.enum_wlr_axis_orientation(orientation), C.double(delta), C.int32_t(deltaDiscrete), C.enum_wlr_axis_source(source))
+func (s Seat) NotifyPointerAxis(time uint32, orientation AxisOrientation, delta float64, deltaDiscrete int32, source AxisSource, relativeDirection RelativeDirection) {
+	C.wlr_seat_pointer_notify_axis(s.p, C.uint32_t(time), C.enum_wl_pointer_axis(orientation), C.double(delta), C.int32_t(deltaDiscrete), C.enum_wl_pointer_axis_source(source), C.enum_wl_pointer_axis_relative_direction(relativeDirection))
 }
 
 func (s Seat) NotifyPointerEnter(surface Surface, sx float64, sy float64) {

--- a/wlroots/server_decoration.go
+++ b/wlroots/server_decoration.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_server_decoration.h>
 import "C"

--- a/wlroots/xcursor.go
+++ b/wlroots/xcursor.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <wlr/xcursor.h>

--- a/wlroots/xwayland.go
+++ b/wlroots/xwayland.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots wayland-server
+// #cgo pkg-config: wlroots-0.18 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <time.h>


### PR DESCRIPTION
Things have fallen a bit out of date. I hope it isn't a big problem that I've grouped a lot of stuff into this PR. To try to make it a bit cleaner it is at least broken up into commits.

The broad strokes of this are:
- Fix two minor typos (`handleOuptuDestroy` -> `handleOutputDestroy`, `PrefferedMode` -> `PreferredMode`)
- Delete obsolete wlroots APIs (mainly: the pending state APIs in `wlr_output_*` and the non-renderpass APIs in `wlr_renderer_*`
- Update bindings for wlroots 0.18:
  - Add `RenderPass` API
  - Add `Display` argument to `NewOutputLayout` and `CreateGlobal`
  - Add relative direction to `NotifyPointerAxis`
  - Remove `Vendor`/`Product` from `InputDevice`, since it's not supported anymore
  - Add `RelativeDirection` enum
  - Switch values of `AxisSource` to use `wl_pointer_axis` enum
  - Add `BeginRenderPass` to replace `AttachRender`
  - Switch `RenderSoftwareCursors` to use `wlr_output_add_software_cursors_to_render_pass`
  - Switch pkg-config package name for wlroots to wlroots-0.18
- Update tinywl to handle the initial commit for XDG surfaces, since wlroots no longer does this automatically
  - Updated tinywl to use toplevel/popup callbacks since it's now necessary
- Update Go dependencies
- Update Nix flake
  - Use `buildGoModule`
  - Avoid using `with` and `rec` as they are no longer best practice
  - Remove usage of `gomod2nix` as it is no longer needed
  - Update all dependencies
  - Apply formatting with `nixfmt`

There are a few minor things. The GeoBox API wrapper contained a pointer field that was only read and never written to, so it was removed, since the two usages of it were broken. Also, there are a lot of things that could be cleaned up or improved in the future. However, I was able to get this working and run applications in it, so hopefully pending any serious issues we can get this moving :)

![image](https://github.com/user-attachments/assets/96d3ce8d-7f99-4477-952d-1b1d4e05874d)
