### PR TITLE
Update for wlroots 0.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
+      - uses: NixOS/nix-installer-action@0dd8719406e061e029989ec91b93d677d9e2bd63
         with:
           diagnostic-endpoint:
-      - uses: DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+      - uses: DeterminateSystems/magic-nix-cache-action@20eea2e172f7f7487136e7a1a2f5b37aeb0e67bd
         with:
           diagnostic-endpoint:
       - name: Build tinywl

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,8 +32,8 @@
             pkgs.wayland
             pkgs.libGL
             pkgs.udev
-            pkgs.xorg.libX11
-            pkgs.xorg.xcbutilwm
+            pkgs.libx11
+            pkgs.libxcb-wm
           ];
           preBuild = ''
             wayland-scanner private-code ${pkgs.wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml wlroots/xdg-shell-protocol.c
@@ -59,8 +59,8 @@
             pkgs.udev
             pkgs.libGL
             pkgs.pixman
-            pkgs.xorg.libX11
-            pkgs.xorg.xcbutilwm
+            pkgs.libx11
+            pkgs.libxcb-wm
           ];
         };
       }

--- a/wlroots/backend.go
+++ b/wlroots/backend.go
@@ -50,10 +50,7 @@ func (b Backend) OnNewOutput(cb func(Output)) {
 func (b Backend) OnNewInput(cb func(InputDevice)) {
 	man.add(unsafe.Pointer(b.p), &b.p.events.new_input, func(data unsafe.Pointer) {
 		dev := wrapInputDevice(data)
-		man.add(unsafe.Pointer(dev.p), &dev.p.events.destroy, func(data unsafe.Pointer) {
-			// delete the wlr_input_device
-			man.delete(unsafe.Pointer(dev.p))
-		})
+		man.track(unsafe.Pointer(dev.p), &dev.p.events.destroy)
 		cb(dev)
 	})
 }

--- a/wlroots/backend.go
+++ b/wlroots/backend.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/backend.h>
 // #include <wlr/render/allocator.h>

--- a/wlroots/buffer.go
+++ b/wlroots/buffer.go
@@ -5,7 +5,7 @@ package wlroots
  * future consistency of this API.
  */
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_buffer.h>
 import "C"

--- a/wlroots/compositor.go
+++ b/wlroots/compositor.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <time.h>

--- a/wlroots/cursor.go
+++ b/wlroots/cursor.go
@@ -35,8 +35,8 @@ func NewCursor() Cursor {
 }
 
 func (c Cursor) Destroy() {
-	C.wlr_cursor_destroy(c.p)
 	man.delete(unsafe.Pointer(c.p))
+	C.wlr_cursor_destroy(c.p)
 }
 
 func (c Cursor) X() float64 {

--- a/wlroots/cursor.go
+++ b/wlroots/cursor.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <wlr/types/wlr_cursor.h>

--- a/wlroots/input_device.go
+++ b/wlroots/input_device.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_input_device.h>
 // #include <wlr/types/wlr_keyboard.h>

--- a/wlroots/keyboard.go
+++ b/wlroots/keyboard.go
@@ -11,7 +11,7 @@ import (
 	"github.com/swaywm/go-wlroots/xkb"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_input_device.h>
 // #include <wlr/types/wlr_keyboard.h>

--- a/wlroots/listener_manager.go
+++ b/wlroots/listener_manager.go
@@ -23,7 +23,7 @@ import (
 //
 // Send help.
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <wayland-server-core.h>

--- a/wlroots/log.go
+++ b/wlroots/log.go
@@ -5,7 +5,7 @@ package wlroots
  * future consistency of this API.
  */
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <stdio.h>

--- a/wlroots/output.go
+++ b/wlroots/output.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/backend/wayland.h>
 // #include <wlr/types/wlr_output.h>
@@ -98,7 +98,7 @@ func (o Output) EffectiveResolution() (int, int) {
  * committed with. A NULL state indicates no change.
  */
 func (o Output) BeginRenderPass(state OutputState) (RenderPass, error) {
-	pass := C.wlr_output_begin_render_pass(o.p, state.p, nil, nil)
+	pass := C.wlr_output_begin_render_pass(o.p, state.p, nil)
 	if pass == nil {
 		return RenderPass{}, errors.New("can't begin render pass")
 	}

--- a/wlroots/render_pass.go
+++ b/wlroots/render_pass.go
@@ -5,7 +5,7 @@ package wlroots
  * future consistency of this API.
  */
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/render/wlr_renderer.h>
 import "C"

--- a/wlroots/renderer.go
+++ b/wlroots/renderer.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/render/wlr_renderer.h>
 import "C"

--- a/wlroots/scene.go
+++ b/wlroots/scene.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_scene.h>
 import "C"

--- a/wlroots/seat.go
+++ b/wlroots/seat.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_seat.h>
 import "C"

--- a/wlroots/server_decoration.go
+++ b/wlroots/server_decoration.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_server_decoration.h>
 import "C"

--- a/wlroots/wlroots.go
+++ b/wlroots/wlroots.go
@@ -5,7 +5,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <time.h>

--- a/wlroots/wlroots.go
+++ b/wlroots/wlroots.go
@@ -19,7 +19,6 @@ import (
 // #include <wlr/types/wlr_xdg_shell.h>
 // #include <wlr/render/wlr_texture.h>
 // #include <wlr/types/wlr_linux_dmabuf_v1.h>
-// #include <wlr/types/wlr_matrix.h>
 // #include <wlr/util/box.h>
 // #include <wlr/util/edges.h>
 import "C"
@@ -96,14 +95,6 @@ func (l OutputLayout) Coords(output Output) (x float64, y float64) {
 }
 
 type Matrix [9]float32
-
-func (m *Matrix) ProjectBox(box *GeoBox, transform uint32, rotation float32, projection *Matrix) {
-	cm := m.toC()
-	b := box.toC()
-	pm := projection.toC()
-	C.wlr_matrix_project_box(&cm[0], &b, C.enum_wl_output_transform(transform), C.float(rotation), &pm[0])
-	m.fromC(&cm)
-}
 
 func (m *Matrix) toC() [9]C.float {
 	var cm [9]C.float

--- a/wlroots/wlroots.go
+++ b/wlroots/wlroots.go
@@ -214,7 +214,11 @@ func (d Display) NewXDGShell(version int) XDGShell {
 func (d Display) XDGShellCreate(version int) XDGShell {
 	p := C.wlr_xdg_shell_create(d.p, C.uint(version))
 	man.track(unsafe.Pointer(p), &p.events.destroy)
-	return XDGShell{p: p}
+	xdgShell := XDGShell{p: p}
+	xdgShell.OnDestroy(func(XDGShell) {
+		man.delete(unsafe.Pointer(p))
+	})
+	return xdgShell
 }
 
 func (d Display) Destroy() {

--- a/wlroots/xcursor.go
+++ b/wlroots/xcursor.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <wlr/xcursor.h>

--- a/wlroots/xdg_shell.go
+++ b/wlroots/xdg_shell.go
@@ -77,16 +77,19 @@ func (s XDGShell) OnNewSurface(cb func(XDGSurface)) {
 			man.delete(unsafe.Pointer(surface.p))
 			man.delete(unsafe.Pointer(surface.TopLevel().p))
 		})
-		man.add(unsafe.Pointer(surface.p.surface), &surface.p.surface.events.destroy, func(data unsafe.Pointer) {
-			man.delete(unsafe.Pointer(surface.p.surface))
-		})
+		man.track(unsafe.Pointer(surface.p.surface), &surface.p.surface.events.destroy)
 		cb(surface)
 	})
 }
 
 func (s XDGShell) OnNewTopLevel(cb func(XDGTopLevel)) {
 	man.add(unsafe.Pointer(s.p), &s.p.events.new_toplevel, func(data unsafe.Pointer) {
-		cb(XDGTopLevel{p: (*C.struct_wlr_xdg_toplevel)(data)})
+		xdgTopLevel := XDGTopLevel{p: (*C.struct_wlr_xdg_toplevel)(data)}
+		man.add(unsafe.Pointer(xdgTopLevel.p), &xdgTopLevel.p.events.destroy, func(data unsafe.Pointer) {
+			man.delete(unsafe.Pointer(xdgTopLevel.p))
+			man.delete(unsafe.Pointer(xdgTopLevel.Base().p))
+		})
+		cb(xdgTopLevel)
 	})
 }
 

--- a/wlroots/xdg_shell.go
+++ b/wlroots/xdg_shell.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <wlr/types/wlr_xdg_shell.h>
 //
@@ -230,11 +230,8 @@ func (x XDGSurface) OnNewPopup(cb func(XDGSurface, XDGPopup)) {
 }
 
 func (x XDGSurface) Geometry() GeoBox {
-	var cb C.struct_wlr_box
-	C.wlr_xdg_surface_get_geometry(x.p, &cb)
-
 	var b GeoBox
-	b.fromC(&cb)
+	b.fromC(&x.p.geometry)
 	return b
 }
 

--- a/wlroots/xwayland.go
+++ b/wlroots/xwayland.go
@@ -39,9 +39,7 @@ func (x XWayland) OnNewSurface(cb func(XWaylandSurface)) {
 	man.add(unsafe.Pointer(x.p), &x.p.events.new_surface, func(data unsafe.Pointer) {
 		surface := XWaylandSurface{p: (*C.struct_wlr_xwayland_surface)(data)}
 		man.track(unsafe.Pointer(surface.p), &surface.p.events.destroy)
-		man.add(unsafe.Pointer(surface.p.surface), &surface.p.surface.events.destroy, func(data unsafe.Pointer) {
-			man.delete(unsafe.Pointer(surface.p.surface))
-		})
+		man.track(unsafe.Pointer(surface.p.surface), &surface.p.surface.events.destroy)
 		cb(surface)
 	})
 }

--- a/wlroots/xwayland.go
+++ b/wlroots/xwayland.go
@@ -7,7 +7,7 @@ package wlroots
 
 import "unsafe"
 
-// #cgo pkg-config: wlroots-0.18 wayland-server
+// #cgo pkg-config: wlroots-0.19 wayland-server
 // #cgo CFLAGS: -D_GNU_SOURCE -DWLR_USE_UNSTABLE
 // #include <stdlib.h>
 // #include <time.h>


### PR DESCRIPTION
Now that wlroots 0.20 is ~~out~~ out soon, it would probably be a good idea to start getting this working with at least wlroots 0.19, if only so that anyone who forks off of this library has a better start. When wlroots 0.20 is in Nixpkgs, I might take another look if I get a chance and see how hard getting it up to 0.20 will be.

- Fixes some cases where event handlers are not cleaned up before destroy properly, since wlroots 0.19 now asserts that this is done properly in more cases.
- Removes deprecated wlr_matrix API usage, since it is now private. The same functionality could be trivially replicated in native Go code anyways.
- Updates the nix flake and all of the pkg-config lines.
- Updates the nix flake to adhere to the latest nixpkgs attribute names for X.org dependencies.

I did my best to test that everything works and makes sense. For example, I tried to replicate all crashes that would be caused by not cleaning up event handlers when testing to make sure that my changes actually worked. So, I think this really is correct. The only part I know is untested is the XWayland part since tinywl doesn't have an XWayland server.

<img width="2127" height="1323" alt="Screenshot_20260218_235609" src="https://github.com/user-attachments/assets/05cadf23-f411-47a4-9941-93c9b15d184d" />
